### PR TITLE
orders can now be filtered by logged in customer with customer in the…

### DIFF
--- a/bangazonapi/views/orders.py
+++ b/bangazonapi/views/orders.py
@@ -79,6 +79,18 @@ class Orders(ViewSet):
         """
         # list of order instances
         orders = Order.objects.all()
+        customer_id = request.auth.user.customer.id
+
+        # filter by the logged in customer
+        is_one_customer = self.request.query_params.get('customer', False)
+        if is_one_customer == 'true':
+            orders = orders.filter(customer__id=customer_id)
+
+        # filter by open orders
+        is_open = self.request.query_params.get('open', False)
+        if is_open == 'true':
+            orders = orders.filter(payment_type__id=None)
+            
         # takes orders and converts to JSON
         serializer = OrderSerializer(
             orders,

--- a/bangazonapi/views/orders.py
+++ b/bangazonapi/views/orders.py
@@ -31,6 +31,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
 class Orders(ViewSet):
     """Orders for Bangazon API"""
 
+
     # Handles POST
     def create(self, request):
         """Handle POST operations
@@ -59,6 +60,9 @@ class Orders(ViewSet):
     def retrieve(self, request, pk=None):
         """Handle GET requests for a single order.
 
+        Fetch call to get one order by order id:
+            http://localhost:8000/orders/${id}
+
         Returns:
             Response -- JSON serialized Order instance
         """
@@ -70,9 +74,21 @@ class Orders(ViewSet):
             return HttpResponseServerError(ex)
 
 
-    # handles GET all
+    # handles GET all, GET by CUSTOMER, and GET by OPEN ORDERS
     def list(self, request):
         """Handle GET requests to orders resource
+
+        Fetch call to get all orders in the database:
+            http://localhost:8000/orders
+
+        Fetch call to get all OPEN orders in the database:
+            http://localhost:8000/orders/?open=true
+
+        Fetch call to get all orders for the logged in customer:
+            http://localhost:8000/orders/?customer=true
+
+        Fetch call to get all OPEN orders for the logged in customer:
+            http://localhost:8000/orders/?customer=true&open=true
 
         Returns:
             Response -- JSON serialized list of orders


### PR DESCRIPTION
Open Orders

# Description

Orders can now be fetched based on logged in customer, and open orders.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing Instructions

checkout into rc-open-order
in postman, make sure you are logged in and have orders from multiple customers, and that your logged in customer has multiple orders but only one open order. 

http://localhost:8000/orders/?customer=true&open=true
The fetch call above should return only the 1 open order for your logged in customer.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
- [x] My functions have doc strings
