### PR TITLE
new orderproducts model, and trailing slash is back to false

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -20,7 +20,7 @@ from rest_framework.authtoken.views import obtain_auth_token
 from bangazonapi.models import *
 from bangazonapi.views import Products, register_user, login_user, Orders, PaymentTypes, OrderProducts, ProductTypes, Customers, Users
 
-router = routers.DefaultRouter(trailing_slash=True)
+router = routers.DefaultRouter(trailing_slash=False)
 
 # This is just a generic route
 # router.register(r'plural', ViewName, 'singular')

--- a/bangazonapi/models/orderproducts.py
+++ b/bangazonapi/models/orderproducts.py
@@ -11,7 +11,7 @@ class OrderProduct(models.Model):
         Author: Michelle Johnson
     """
 
-    order = models.ForeignKey(Order, on_delete=models.DO_NOTHING)
+    order = models.ForeignKey(Order, on_delete=models.CASCADE)
     product = models.ForeignKey(Product, on_delete=models.DO_NOTHING)
 
     class Meta:


### PR DESCRIPTION
# Description

Order Products model changed so that they cascade delete when an order is cancelled.
Trailing slash changed back to False.

Fixes # (issue)
## Type of change
Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions

add and commit your current branch
`git checkout master`
`git fetch -all`
`git checkout rc-trailing-slash`
`python manage.py makemigrations`
`python manage.py migrate`

some things may be broken, that will be fixed on Ken's Client Side PR

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
- [x] My functions have doc strings
