### PR TITLE
Lr cc exp date

### DIFF
--- a/bangazonapi/models/paymenttypes.py
+++ b/bangazonapi/models/paymenttypes.py
@@ -2,6 +2,8 @@ from .customers import Customer
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE
 from django.db import models
+from creditcards.models import CardExpiryField
+
 
 class PaymentType(SafeDeleteModel):
     '''
@@ -12,7 +14,7 @@ class PaymentType(SafeDeleteModel):
 
     merchant_name = models.CharField(max_length=25)
     account_number = models.CharField(max_length=25)
-    expiration_date = models.DateTimeField(auto_now=False, auto_now_add=True)
+    expiration_date = CardExpiryField(('expiration date'))
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING)
     created_at = models.DateTimeField(auto_now=False, auto_now_add=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ autopep8==1.5
 colorama==0.4.3
 Django==3.0.3
 django-cors-headers==3.2.1
+django-credit-cards==0.4.1
 django-safedelete==0.5.4
 djangorestframework==3.11.0
 isort==4.3.21


### PR DESCRIPTION
# Description
User should be able to input Credit Card exp date and it should show up as 2020-12-31 format in DB.
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions
1. `pip install django-credit-cards`
2. `python manage.py makemigrations bangazonapi`
3. `python manage.py migrate`
4. Go to client and chekcout my branch and follow PR instructions to test. User should be able to input Credit Card exp date and it should show up as 2020-12-31 format in DB.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
- [x] My functions have doc strings
