### PR TITLE
Rc number sold

### DIFF
--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from django.test import TestCase
 from django.urls import reverse
-from bangazonapi.models import Product, Customer, ProductType
+from bangazonapi.models import Product, Customer, ProductType, Order, PaymentType
 from django.contrib.auth.models import User
 from rest_framework.authtoken.models import Token
 
@@ -19,6 +19,10 @@ class TestProducts(TestCase):
         self.token = Token.objects.create(user=self.user)
         self.customer = Customer.objects.create(user_id=1)
         self.product_type = ProductType.objects.create(name="type for testing")
+        self.payment_type = PaymentType.objects.create(merchant_name="Visa", account_number="1234567", created_at="2020-03-04 20:41:57.004509", customer_id=self.customer.id, expiration_date="3020-12-31")
+        self.order1 = Order.objects.create(created_at="2020-02-24 15:32:15.551752", customer_id=self.customer.id, payment_type_id=self.payment_type.id)
+        self.order2 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id, payment_type_id=self.payment_type.id)
+        self.order3 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id)
 
     def test_post_product(self):
         # define a product to be sent to the API
@@ -49,14 +53,14 @@ class TestProducts(TestCase):
 
     def test_get_product(self):
         new_product = Product.objects.create(
-        name = "Hot Dog",
-        price = 3.00,
-        description = "Real good, fresh and not expired.",
-        quantity = 11,
-        location = "Franklin",
-        image_path = "./none_pic.jpg",
-        customer_id = self.customer.id,
-        product_type_id = self.product_type.id
+            name = "Hot Dog",
+            price = 3.00,
+            description = "Real good, fresh and not expired.",
+            quantity = 11,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
         )
 
         # Now we can grab all the products (meaning the one we just created) from the db

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -82,6 +82,34 @@ class TestProducts(TestCase):
         # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
         self.assertIn(new_product.name.encode(), response.content)
 
+    def test_delete_product(self):
+        # Create a product
+        new_product = Product.objects.create(
+            name = "Hot Dog",
+            price = 3.00,
+            description = "Real good, fresh and not expired.",
+            quantity = 11,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
+        )
+
+
+        # Delete a product. As shown in our post and get tests above, new_product
+        # will be the only product in the database, and will have an id of 1
+        response = self.client.delete(
+            reverse('product-detail', kwargs={'pk': 1}), HTTP_AUTHORIZATION='Token ' + str(self.token))
+
+        self.assertEqual(response.status_code, 204)
+
+        # Confirm that the product is NOT in the database, which means no products will be
+        # response = self.client.get(reverse('product-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+        # self.assertEqual(len(response.data), 0)
+        response = self.client.get(reverse('product-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+        self.assertEqual(len(response.data), 0)
+
+
     @skip("still working on this.")
     def test_num_sold(self):
         #  Create a new product.

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -1,10 +1,9 @@
 from rest_framework import status
 from django.test import TestCase
 from django.urls import reverse
-from bangazonapi.models import Product, Customer, ProductType, Order, PaymentType
+from bangazonapi.models import Product, Customer, ProductType, Order, PaymentType, OrderProduct
 from django.contrib.auth.models import User
 from rest_framework.authtoken.models import Token
-from unittest import skip
 
 """Tests for the product and product detail endpoints.
 
@@ -23,8 +22,11 @@ class TestProducts(TestCase):
         self.user = User.objects.create_user(username=self.username, password=self.password)
         self.token = Token.objects.create(user=self.user)
         self.customer = Customer.objects.create(user_id=1)
+
         self.product_type = ProductType.objects.create(name="type for testing")
         self.payment_type = PaymentType.objects.create(merchant_name="Visa", account_number="1234567", created_at="2020-03-04 20:41:57.004509", customer_id=self.customer.id, expiration_date="3020-12-31")
+
+        # Creating 3 orders. Orders 1 and 2 will be closed, and order 3 will be open.
         self.order1 = Order.objects.create(created_at="2020-02-24 15:32:15.551752", customer_id=self.customer.id, payment_type_id=self.payment_type.id)
         self.order2 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id, payment_type_id=self.payment_type.id)
         self.order3 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id)
@@ -167,16 +169,37 @@ class TestProducts(TestCase):
         self.assertEqual(len(response.data), 0)
 
 
-    @skip("still working on this.")
     def test_num_sold(self):
         #  Create a new product.
+        new_product = Product.objects.create(
+            name = "Hot Dog",
+            price = 3.00,
+            description = "Real good, fresh and not expired.",
+            quantity = 11,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
+        )
 
         # Create an order product connecting the product to order 1 (sold)
+        first_order_product = OrderProduct.objects.create(order_id=self.order1.id, product_id=1)
 
         # Create an order product connecting the product to order 2 (sold)
+        second_order_product = OrderProduct.objects.create(order_id=self.order2.id, product_id=1)
 
         # Create an order product connecting the product to order 3 (not sold)
-        pass
+        third_order_product = OrderProduct.objects.create(order_id=self.order3.id, product_id=1)
+        
+        # Call function for custom action num_sold
+        response = self.client.get(
+            '/products/num_sold?product_id=1', HTTP_AUTHORIZATION='Token ' + str(self.token)
+        )
+
+        # There should be 3 order products that the order is on. 2 of those order products
+        # have foreign keys representing closed orders. 
+        # Therefore, this product has been sold twice. Confirm that with an assertion.
+        self.assertEqual(response.data["total_sold"], 2)
 
 
 if __name__ == '__main__':

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from bangazonapi.models import Product, Customer, ProductType, Order, PaymentType
 from django.contrib.auth.models import User
 from rest_framework.authtoken.models import Token
+from unittest import skip
 
 
 
@@ -80,6 +81,17 @@ class TestProducts(TestCase):
         # Finally, test the actual rendered content as the client would receive it.
         # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
         self.assertIn(new_product.name.encode(), response.content)
+
+    @skip("still working on this.")
+    def test_num_sold(self):
+        #  Create a new product.
+
+        # Create an order product connecting the product to order 1 (sold)
+
+        # Create an order product connecting the product to order 2 (sold)
+
+        # Create an order product connecting the product to order 3 (not sold)
+        pass
 
 
 if __name__ == '__main__':

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -6,7 +6,11 @@ from django.contrib.auth.models import User
 from rest_framework.authtoken.models import Token
 from unittest import skip
 
+"""Tests for the product and product detail endpoints.
 
+Author:
+    Ryan Crowley
+"""
 
 print("test file loaded------------------------")
 
@@ -25,7 +29,9 @@ class TestProducts(TestCase):
         self.order2 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id, payment_type_id=self.payment_type.id)
         self.order3 = Order.objects.create(created_at="2020-02-25 15:32:15.551752", customer_id=self.customer.id)
 
+
     def test_post_product(self):
+        """TEST for create method on products view"""
         # define a product to be sent to the API
         new_product = {
               "name": "Hot Dog",
@@ -52,7 +58,10 @@ class TestProducts(TestCase):
         # And see if it's the one we just added by checking one of the properties. Here, name.
         self.assertEqual(Product.objects.get().name, 'Hot Dog')
 
+
     def test_get_product(self):
+        """TEST for list method on products view"""
+
         new_product = Product.objects.create(
             name = "Hot Dog",
             price = 3.00,
@@ -82,7 +91,55 @@ class TestProducts(TestCase):
         # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
         self.assertIn(new_product.name.encode(), response.content)
 
+
+    def test_get_one_product(self):
+        """TEST for retrieve method on products view"""
+
+        # Create 2 products
+        product_one = Product.objects.create(
+            name = "Hot Dog",
+            price = 3.00,
+            description = "Real good, fresh and not expired.",
+            quantity = 11,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
+        )
+
+        product_two = Product.objects.create(
+            name = "Cheesburger",
+            price = 5.00,
+            description = "Medium well!",
+            quantity = 9,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
+        )
+
+        # Retrieve product 1
+        response = self.client.get(
+            reverse('product-detail', kwargs={'pk': 1}), HTTP_AUTHORIZATION='Token ' + str(self.token)
+        )
+
+        # Assert 200 response status and name == Hot Dog
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Hot Dog")
+
+        # Retrieve product 2
+        response = self.client.get(
+            reverse('product-detail', kwargs={'pk': 2}), HTTP_AUTHORIZATION='Token ' + str(self.token)
+        )
+
+        # Assert 200 response status and name == Cheesburger
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["name"], "Cheesburger")
+
+
     def test_delete_product(self):
+        """TEST for destroy method on products view"""
+
         # Create a product
         new_product = Product.objects.create(
             name = "Hot Dog",

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -47,28 +47,35 @@ class TestProducts(TestCase):
         # And see if it's the one we just added by checking one of the properties. Here, name.
         self.assertEqual(Product.objects.get().name, 'Hot Dog')
 
-    # def test_get_product_type(self):
-    #     new_product_type = ProductType.objects.create(
-    #       name="Sporting Goods"
-    #     )
+    def test_get_product(self):
+        new_product = Product.objects.create(
+        name = "Hot Dog",
+        price = 3.00,
+        description = "Real good, fresh and not expired.",
+        quantity = 11,
+        location = "Franklin",
+        image_path = "./none_pic.jpg",
+        customer_id = self.customer.id,
+        product_type_id = self.product_type.id
+        )
 
-    #     # Now we can grab all the product types (meaning the one we just created) from the db
-    #     response = self.client.get(reverse('producttype-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+        # Now we can grab all the products (meaning the one we just created) from the db
+        response = self.client.get(reverse('product-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
 
-    #     # Check that the response is 200 OK.
-    #     # This is checking for the GET request result, not the POST. We already checked that POST works in the previous test!
-    #     self.assertEqual(response.status_code, 200)
+        # Check that the response is 200 OK.
+        # This is checking for the GET request result, not the POST. We already checked that POST works in the previous test!
+        self.assertEqual(response.status_code, 200)
 
-    #     # response.data is the python serialised data used to render the JSON, while response.content is the JSON itself.
-    #     # Are we responding with the data we asked for? There's just one product type in our dummy db, so it should contain a list with one instance in it
-    #     self.assertEqual(len(response.data), 1)
+        # response.data is the python serialised data used to render the JSON, while response.content is the JSON itself.
+        # Are we responding with the data we asked for? There's just one product in our dummy db, so it should contain a list with one instance in it
+        self.assertEqual(len(response.data), 1)
 
-    #     # test the contents of the data before it's serialized into JSON
-    #     self.assertEqual(response.data[0]["name"], "Sporting Goods")
+        # test the contents of the data before it's serialized into JSON
+        self.assertEqual(response.data[0]["name"], "Hot Dog")
 
-    #     # Finally, test the actual rendered content as the client would receive it.
-    #     # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
-    #     self.assertIn(new_product_type.name.encode(), response.content)
+        # Finally, test the actual rendered content as the client would receive it.
+        # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
+        self.assertIn(new_product.name.encode(), response.content)
 
 
 if __name__ == '__main__':

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -197,7 +197,6 @@ class TestProducts(TestCase):
               "product_type_id": new_product.product_type_id
             }
 
-
         # Update new_product
         response = self.client.put(
             reverse('product-detail', kwargs={'pk': 1}), 
@@ -209,12 +208,11 @@ class TestProducts(TestCase):
         # Assert that the put returns the expected 204 status
         self.assertEqual(response.status_code, 204)
 
-
         # Get the product again, it should now be the updated product.
         response = self.client.get(
             reverse('product-detail', kwargs={'pk': 1}), HTTP_AUTHORIZATION='Token ' + str(self.token)
         )
-
+        
         # Assert that the product name is now "Corn Dawg"
         self.assertEqual(response.data["name"], "Corn Dawg")
 

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -1,3 +1,4 @@
+import json
 from rest_framework import status
 from django.test import TestCase
 from django.urls import reverse
@@ -168,6 +169,54 @@ class TestProducts(TestCase):
         response = self.client.get(reverse('product-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
         self.assertEqual(len(response.data), 0)
 
+
+    def test_edit_product(self):
+        """TEST for update method on products view"""
+
+        # Create a product that you will edit
+        new_product = Product.objects.create(
+            name = "Hot Dog",
+            price = 3.00,
+            description = "Real good, fresh and not expired.",
+            quantity = 11,
+            location = "Franklin",
+            image_path = "./none_pic.jpg",
+            customer_id = self.customer.id,
+            product_type_id = self.product_type.id
+        )
+
+        # Create new updated object. Change the name to "Corn Dawg"
+        updated_product = {
+              "name": "Corn Dawg",
+              "price": new_product.price,
+              "description": new_product.description,
+              "quantity": new_product.quantity,
+              "location": new_product.location,
+              "image_path": new_product.image_path,
+              "customer_id": new_product.customer_id,
+              "product_type_id": new_product.product_type_id
+            }
+
+
+        # Update new_product
+        response = self.client.put(
+            reverse('product-detail', kwargs={'pk': 1}), 
+            updated_product,
+            content_type='application/json',
+            HTTP_AUTHORIZATION='Token ' + str(self.token)
+        )
+
+        # Assert that the put returns the expected 204 status
+        self.assertEqual(response.status_code, 204)
+
+
+        # Get the product again, it should now be the updated product.
+        response = self.client.get(
+            reverse('product-detail', kwargs={'pk': 1}), HTTP_AUTHORIZATION='Token ' + str(self.token)
+        )
+
+        # Assert that the product name is now "Corn Dawg"
+        self.assertEqual(response.data["name"], "Corn Dawg")
 
     def test_num_sold(self):
         #  Create a new product.

--- a/bangazonapi/tests/testProducts.py
+++ b/bangazonapi/tests/testProducts.py
@@ -1,0 +1,75 @@
+from rest_framework import status
+from django.test import TestCase
+from django.urls import reverse
+from bangazonapi.models import Product, Customer, ProductType
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+
+
+
+print("test file loaded------------------------")
+
+
+class TestProducts(TestCase):
+    # used to get user auth to work
+    def setUp(self):
+        self.username = 'testuser'
+        self.password = 'foobar'
+        self.user = User.objects.create_user(username=self.username, password=self.password)
+        self.token = Token.objects.create(user=self.user)
+        self.customer = Customer.objects.create(user_id=1)
+        self.product_type = ProductType.objects.create(name="type for testing")
+
+    def test_post_product(self):
+        # define a product to be sent to the API
+        new_product = {
+              "name": "Hot Dog",
+              "price": 3.00,
+              "description": "Real good, fresh and not expired.",
+              "quantity": 11,
+              "location": "Franklin",
+              "image_path": "./none_pic.jpg",
+              "customer_id": self.customer.id,
+              "product_type_id": self.product_type.id
+            }
+        
+        #  Use the client to send the request and store the response
+        response = self.client.post(
+            reverse('product-list'), new_product, HTTP_AUTHORIZATION='Token ' + str(self.token)
+          )
+
+        # Getting 200 back because we have a success url
+        self.assertEqual(response.status_code, 200)
+
+        # Query the table to see if there's one Product instance in there. Since we are testing a POST request, we don't need to test whether an HTTP GET works. So, we just use the ORM to see if the thing we saved is in the db.
+        self.assertEqual(Product.objects.count(), 1)
+
+        # And see if it's the one we just added by checking one of the properties. Here, name.
+        self.assertEqual(Product.objects.get().name, 'Hot Dog')
+
+    # def test_get_product_type(self):
+    #     new_product_type = ProductType.objects.create(
+    #       name="Sporting Goods"
+    #     )
+
+    #     # Now we can grab all the product types (meaning the one we just created) from the db
+    #     response = self.client.get(reverse('producttype-list'), HTTP_AUTHORIZATION='Token ' + str(self.token))
+
+    #     # Check that the response is 200 OK.
+    #     # This is checking for the GET request result, not the POST. We already checked that POST works in the previous test!
+    #     self.assertEqual(response.status_code, 200)
+
+    #     # response.data is the python serialised data used to render the JSON, while response.content is the JSON itself.
+    #     # Are we responding with the data we asked for? There's just one product type in our dummy db, so it should contain a list with one instance in it
+    #     self.assertEqual(len(response.data), 1)
+
+    #     # test the contents of the data before it's serialized into JSON
+    #     self.assertEqual(response.data[0]["name"], "Sporting Goods")
+
+    #     # Finally, test the actual rendered content as the client would receive it.
+    #     # .encode converts from unicode to utf-8. Don't get hung up on this. It's just how we can compare apples to apples
+    #     self.assertIn(new_product_type.name.encode(), response.content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bangazonapi/views/products.py
+++ b/bangazonapi/views/products.py
@@ -33,17 +33,37 @@ class Products(ViewSet):
     """products for bangazon"""
 
     # Custom action to get the number of products sold for specific product
-    # http://localhost:8000/products/num_sold/product_id
     @action(methods=['get'], detail=False)
-    def num_sold(self, request, product_id):
-        # SQL query here somehow. WHERE op.product_id = 4 will have 4 replaced with product_id
-        # SELECT COUNT() as "Number Sold"
-        # FROM bangazonapi_orderproduct op
-        # JOIN bangazonapi_order o
-        # ON op.order_id = o.id
-        # WHERE op.product_id = 4
-        # AND o.payment_type_id is not NULL
-        pass
+    def num_sold(self, request):
+        """Handle requests total sold of a product.
+
+        Fetch call to get number sold for a product:
+            http://localhost:8000/products/num_sold?product_id=PRODUCT_ID_GOES_HERE
+
+        Author:
+            Ryan Crowley
+
+        Returns:
+        """
+
+
+        product_id = self.request.query_params.get('product_id', False)
+
+        if product_id:
+            print("Product id: ", product_id)
+        else:
+            print("No product ID")
+        # total_sold = Product.objects.raw(
+        #     '''SELECT COUNT() as "Number Sold"
+        #         FROM bangazonapi_orderproduct op
+        #         JOIN bangazonapi_order o
+        #         ON op.order_id = o.id
+        #         WHERE op.product_id = ?
+        #         AND o.payment_type_id is not NULL''', product_id
+        # )
+
+        # print("Total Sold: ", total_sold)
+        # print("Type of total sold: ", type(total_sold))
 
     def create(self, request):
         """Handle POST operations

--- a/bangazonapi/views/products.py
+++ b/bangazonapi/views/products.py
@@ -33,6 +33,7 @@ class Products(ViewSet):
     """products for bangazon"""
 
     # Custom action to get the number of products sold for specific product
+    # http://localhost:8000/products/num_sold/product_id
     @action(methods=['get'], detail=False)
     def num_sold(self, request, product_id):
         # SQL query here somehow. WHERE op.product_id = 4 will have 4 replaced with product_id

--- a/bangazonapi/views/products.py
+++ b/bangazonapi/views/products.py
@@ -34,7 +34,7 @@ class Products(ViewSet):
     """products for bangazon"""
 
     # Custom action to get the number of products sold for specific product
-    @action(methods=['get'], detail=False)
+    @action(methods=['get'], detail=False, url_name="num_sold")
     def num_sold(self, request):
         """Handle requests total sold of a product.
 
@@ -64,7 +64,7 @@ class Products(ViewSet):
 
             row = cursor.fetchone()
             # row[0] will contain the integer representing total sold for this product.
-            total = {"total": row[0]}
+            total = {"total_sold": row[0]}
 
             # Return a JSON response
             return Response(total)

--- a/bangazonapi/views/products.py
+++ b/bangazonapi/views/products.py
@@ -45,9 +45,13 @@ class Products(ViewSet):
             Ryan Crowley
 
         Returns:
+            Response - JSON object with "total" as the key and an integer as the value
         """
+
+        # Get the product ID from the query params
         product_id = int(self.request.query_params.get('product_id'))
 
+        # query the database
         with connection.cursor() as cursor:
             cursor.execute(
                 '''SELECT COUNT() as "Number Sold"
@@ -59,8 +63,10 @@ class Products(ViewSet):
             )
 
             row = cursor.fetchone()
+            # row[0] will contain the integer representing total sold for this product.
             total = {"total": row[0]}
 
+            # Return a JSON response
             return Response(total)
 
 

--- a/bangazonapi/views/products.py
+++ b/bangazonapi/views/products.py
@@ -4,6 +4,7 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
+from rest_framework.decorators import action
 from bangazonapi.models import Product
 from .customers import CustomersSerializer
 
@@ -30,6 +31,18 @@ class ProductsSerializer(serializers.HyperlinkedModelSerializer):
 
 class Products(ViewSet):
     """products for bangazon"""
+
+    # Custom action to get the number of products sold for specific product
+    @action(methods=['get'], detail=False)
+    def num_sold(self, request, product_id):
+        # SQL query here somehow. WHERE op.product_id = 4 will have 4 replaced with product_id
+        # SELECT COUNT() as "Number Sold"
+        # FROM bangazonapi_orderproduct op
+        # JOIN bangazonapi_order o
+        # ON op.order_id = o.id
+        # WHERE op.product_id = 4
+        # AND o.payment_type_id is not NULL
+        pass
 
     def create(self, request):
         """Handle POST operations


### PR DESCRIPTION
# Description

The products view now has a custom action, num_sold, that will return the total sold of a particular product.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions:

Add and commit your current branch
`git checkout master`
`git fetch --all`
`git checkout rc-number-sold`

Run `python manage.py test` (or `python manage.py test bangazonapi`) and confirm that all tests come back ok.

In Postman, go to http://localhost:8000/products/num_sold?product_id=1 (or product_id= any valid product id) and perform a "GET" request.
You should get a response of "total_sold": 0 or how many have sold.

Try this out with product_id's that don't exist, have sold zero, have sold some, have sold some and also exist on open orders, etc. Try and break it and let me know.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
- [x] My functions have doc strings
